### PR TITLE
Pass `skipSaveParticipants: true` for `save`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ This is a VS Code extension that lets you toggle documents to save (without form
 
 After installing, execute the command **Save Constantly: Toggle** (bound to **`alt+s`** by default) to enable for the document associated with the active editor. Repeat to disable.
 
-## Issues
-
-If a change occurs in a file with Save Constantly enabled but not currently associated with the active editor, it will not be saved; see [this Stack Overflow question](https://stackoverflow.com/q/79550924/5044950) for more details.
-
 ## Related
 
 Michel Betancourt's [Save Typing](https://marketplace.visualstudio.com/items?itemName=akhail.save-typing) extension is similar, but has a couple drawbacks:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,17 +7,8 @@ export const activate = (context: vscode.ExtensionContext) => {
   log.info("activating Save Constantly extension");
 
   const save = async (document: vscode.TextDocument) => {
-    const { fileName } = document;
-    log.trace("saving", fileName);
-    const active = vscode.window.activeTextEditor?.document.fileName;
-    if (fileName !== active) {
-      // https://stackoverflow.com/q/79550924/5044950
-      log.warn("can't save a file different from the active document", active);
-      return;
-    }
-    await vscode.commands.executeCommand(
-      "workbench.action.files.saveWithoutFormatting",
-    );
+    log.trace("saving", document.fileName);
+    await document.save({ skipSaveParticipants: true });
   };
 
   const files = new Set<string>();


### PR DESCRIPTION
This doesn't actually work in VS Code as of version 1.98, as suggested by the fact that TypeScript rejects this code. I'm opening this PR to demonstrate this use case, so I can link to it from a pull request I'm about to open on the VS Code repo.