### PR TITLE
Try just disabling and restoring relevant settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ After installing, execute the command **Save Constantly: Toggle** (bound to **`a
 
 ## Issues
 
+Because VS Code lacks an API to save an arbitrary file without formatting (see [microsoft/vscode#245405](https://github.com/microsoft/vscode/issues/245405)), this extension does the best it can by attempting to temporarily disable the following settings while saving, similar to Gruntfuggly's now-deprecated [Save Without Format](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.save-without-format) extension:
+
+- `editor.formatOnSave`
+- `files.insertFinalNewline`
+- `files.trimFinalNewlines`
+- `files.trimTrailingWhitespace`
+
+However, this has a couple drawbacks:
+
+- The latency is much higher than it should be, negating the benefit of disabling autoformatting.
+- It is possible for there to be a race condition in which the configuration is changed while the file is being saved, causing the setting to erroneously revert back to its previous value.
+- By modifying the configuration, this extension adds those settings to the `.vscode/settings.json` file in the current workspace, even if that file didn't already exist or contain those settings.
+
 If a change occurs in a file with Save Constantly enabled but not currently associated with the active editor, it will not be saved; see [this Stack Overflow question](https://stackoverflow.com/q/79550924/5044950) for more details.
 
 ## Related


### PR DESCRIPTION
This PR attempts to work around the VS Code API limitation by using the same [strategy](https://github.com/Gruntfuggly/save-without-format/blob/6ba4afe2205dadb66e6bb13080b430d8c524c8a4/extension.js#L5-L16) as the Save Without Format extension that was eventually replaced by the `workbench.action.files.saveWithoutFormatting` command. Unfortunately, this approach turned out to be far worse than I expected, as I've documented in my `README.md` changes here.